### PR TITLE
FIX: fix nil block panic in worker

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -303,7 +303,7 @@ func (self *worker) wait() {
 		for result := range self.recv {
 			atomic.AddInt32(&self.atWork, -1)
 
-			if result == nil {
+			if result == nil || result.Block == nil {
 				continue
 			}
 			block := result.Block


### PR DESCRIPTION
When stop channel received signal, mintLoop return a nil block. Ignore it.
cc @git-hulk 